### PR TITLE
Updating main.tf (line 16)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ data "ibm_resource_group" "resource_group" {
 
 locals {
   name_prefix = var.name_prefix != "" ? var.name_prefix : var.resource_group_name
-  name        = var.name != "" ? var.name : "${replace(local.name_prefix, "/[^a-zA-Z0-9_\\-\\.]/", "")}-hpcs"  
+  name        = var.name != "" ? var.name : "${replace(local.name_prefix, "/[^a-zA-Z0-9_\\-\\.]/", "")}-hpvs"  
 }
 
 resource "ibm_resource_instance" "hpvs_instance" {


### PR DESCRIPTION
There is a lingering 'hpcs' reference in line 16, which should be 'hpvs' instead. 

name        = var.name != "" ? var.name : "${replace(local.name_prefix, "/[^a-zA-Z0-9_\\-\\.]/", "")}-hpcs"

When creating the instance name, the string post hyphen should be labeled as 'hpvs', to coincide with the provisioned service.